### PR TITLE
Add CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,25 @@ Alternatively however,  you can edit the `transcribe` function in `audio.py` and
 
 ## Usage
 The Earmark class provides an object oriented wrapper around the functions of `audio.py` and `search.py` for your convenience. Ensure you have edited `config.toml` with the appropriate paths and values (or passed them appropriately as keyword arguments). 
+
+Earmark can be used in two ways, either as a command line interface or as python module.
+
+### Module
+To use as a module see the code below
 ```
 import earmark
 em = earmark.Earmark(configPath="config.toml")
-em.execute()
+em.run()
 ```
+
+### CLI
+Thanks to the wonderful [fire](https://github.com/google/python-fire) Earmark now has a CLI! Simply execute it as follows:
+```
+$ python3 earmark.py --cfg=config.toml run
+```
+Bam! And thats it!
+
+---
 It will now transcribe segments of your audiobook and identify the respective kindle locations (nearly) automatically! Be advised user input may be needed to select correctly matching text if it cannot be detemined automatically.
 
 The output will be printed into a json file, `output.json` in the same directory by default.

--- a/audio.py
+++ b/audio.py
@@ -28,9 +28,4 @@ def transcribe(inputFile):
 	
 
 if __name__ == '__main__':
-	args = sys.argv # [current file, function name , *args]
-	try:
-		globals()[args[1]](*args[2:])
-	except IndexError:
-		#script was called without any commandline arguments, otherwise it would error with IndexError
-		pass
+	pass

--- a/earmark.py
+++ b/earmark.py
@@ -22,6 +22,9 @@ class Earmark():
 			#init Earmark by config file
 			with open(configPath, "r") as tomlFile:
 				initializationArguments = toml.load(tomlFile)
+		elif "cfg" in kwargs:
+			with open(kwargs["cfg"], "r") as tomlFile:
+				initializationArguments = toml.load(tomlFile)
 		else:
 			#explicitly told to ignore config file
 			initializationArguments = kwargs

--- a/earmark.py
+++ b/earmark.py
@@ -5,6 +5,7 @@ import toml
 import os
 import json
 from datetime import datetime
+import fire
 
 
 class Earmark():
@@ -131,3 +132,6 @@ class Earmark():
 			excerpt["location"]=location
 			locations.append(excerpt)
 		return locations #list of dictionaries in format: [{"confidenceLevel" : int, "text" : matching text, "file" : path to html file, "location" : int}]
+
+if __name__ == "__main__":
+	fire.Fire(Earmark)

--- a/earmark.py
+++ b/earmark.py
@@ -48,7 +48,7 @@ class Earmark():
 		#output files
 		self.apiCache=initializationArguments["apiCache"]
 
-	def execute(self):
+	def run(self):
 		transcriptions = self.processAudiobook()
 		for transcript in transcriptions:
 			logging.info(f"{transcript['file']} : {transcript['text']}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cachetools==5.3.2
 certifi==2023.11.17
 cffi==1.16.0
 charset-normalizer==3.3.2
-EbookLib @ git+https://github.com/aerkalov/ebooklib.git@1cb3d2c251f82c4702c2aff0ed7aea375babf251
+fire==0.5.0
 google-api-core==2.15.0
 google-auth==2.26.1
 google-cloud-speech==2.23.0
@@ -15,7 +15,6 @@ idna==3.6
 inflect==7.0.0
 loguru==0.6.0
 lxml==5.0.0
-mobi==0.3.3
 proto-plus==1.23.0
 protobuf==4.25.1
 pyasn1==0.5.1
@@ -28,10 +27,13 @@ python-dotenv==1.0.0
 rapidfuzz==3.6.1
 requests==2.31.0
 rsa==4.9
+six==1.16.0
 soupsieve==2.5
 SpeechRecognition==3.10.1
 srt==3.5.3
+termcolor==2.4.0
 thefuzz==0.20.0
+toml==0.10.2
 tqdm==4.66.1
 typing_extensions==4.9.0
 urllib3==2.1.0

--- a/search.py
+++ b/search.py
@@ -147,11 +147,6 @@ def calculateLocation(numBytes):
 
 
 if __name__ == '__main__':
-	# see comment in main.py
-	args = sys.argv
-	try:
-		globals()[args[1]](*args[2:])
-	except IndexError:
-		pass
+	pass
 
 		


### PR DESCRIPTION
Using the wonderful fire library Earmark now has a CLI!

changes:
- removed `sys.argv` block in the name-main block of each file
- renamed `Earmark.execute()` to `Earmark.run()`
- added "cfg" as an alias for "configPath" to make cli less cumbersome 
- most importantly: added fire cli wrapper in name-main block of `earmark.py`